### PR TITLE
Fix latest Jekyll calling extname on Layout class

### DIFF
--- a/lib/jekyll/slim/extensions.rb
+++ b/lib/jekyll/slim/extensions.rb
@@ -53,5 +53,6 @@ module Jekyll
 
     alias_method :initialize_without_pretransform, :initialize
     alias_method :initialize, :initialize_with_pretransform
+    alias_method :extname, :ext
   end
 end


### PR DESCRIPTION
Same explanation as the previous PR: https://github.com/kesha-antonov/jekyll-slim/pull/1#issue-71157933

Figured I'd toss this back to your fork. With this small tweak, this works for me with the latest Jekyll (3.8.3).

```
MethodError: undefined method `extname' for
  /home/mcnelson/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/renderer.rb:38:in
  `block in converters'
```